### PR TITLE
Harden event API validation for create and update routes

### DIFF
--- a/src/lib/server/validation/events.ts
+++ b/src/lib/server/validation/events.ts
@@ -1,0 +1,272 @@
+type ValidationErrors = Record<string, string>;
+
+type ValidationOk<T> = { ok: true; value: T };
+type ValidationFail = { ok: false; errors: ValidationErrors };
+
+type EventCreatePayload = {
+	organizationId: string;
+	title: string;
+	description?: string | null;
+	location: string;
+	startTime: Date;
+	endTime: Date;
+	maxCapacity?: number | null;
+	registrationRequired?: boolean;
+};
+
+type EventUpdatePayload = {
+	title?: string;
+	description?: string | null;
+	location?: string;
+	startTime?: Date;
+	endTime?: Date;
+	maxCapacity?: number | null;
+	registrationRequired?: boolean;
+};
+
+type EventUpdateContext = {
+	existingStartTime?: Date;
+	existingEndTime?: Date;
+};
+
+const createAllowedFields = new Set([
+	'organizationId',
+	'title',
+	'description',
+	'location',
+	'startTime',
+	'endTime',
+	'maxCapacity',
+	'registrationRequired'
+]);
+
+const updateAllowedFields = new Set([
+	'title',
+	'description',
+	'location',
+	'startTime',
+	'endTime',
+	'maxCapacity',
+	'registrationRequired'
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function addError(errors: ValidationErrors, field: string, message: string) {
+	if (!errors[field]) errors[field] = message;
+}
+
+function parseDateValue(value: unknown): Date | null {
+	if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+	if (typeof value === 'string') {
+		const parsed = new Date(value);
+		return Number.isNaN(parsed.getTime()) ? null : parsed;
+	}
+	return null;
+}
+
+function parseRequiredString(
+	value: unknown,
+	field: string,
+	errors: ValidationErrors
+): string | undefined {
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		addError(errors, field, `${field} is required`);
+		return undefined;
+	}
+	return value.trim();
+}
+
+function parseOptionalNonEmptyString(
+	value: unknown,
+	field: string,
+	errors: ValidationErrors
+): string | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		addError(errors, field, `${field} must be a non-empty string`);
+		return undefined;
+	}
+	return value.trim();
+}
+
+function parseOptionalNullableString(
+	value: unknown,
+	field: string,
+	errors: ValidationErrors
+): string | null | undefined {
+	if (value === undefined) return undefined;
+	if (value === null) return null;
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		addError(errors, field, `${field} must be a non-empty string or null`);
+		return undefined;
+	}
+	return value.trim();
+}
+
+function parseRequiredDate(
+	value: unknown,
+	field: string,
+	errors: ValidationErrors
+): Date | undefined {
+	const parsed = parseDateValue(value);
+	if (!parsed) {
+		addError(errors, field, `${field} must be a valid ISO date string`);
+		return undefined;
+	}
+	return parsed;
+}
+
+function parseOptionalDate(
+	value: unknown,
+	field: string,
+	errors: ValidationErrors
+): Date | undefined {
+	if (value === undefined) return undefined;
+	const parsed = parseDateValue(value);
+	if (!parsed) {
+		addError(errors, field, `${field} must be a valid ISO date string`);
+		return undefined;
+	}
+	return parsed;
+}
+
+function parseOptionalInteger(
+	value: unknown,
+	field: string,
+	errors: ValidationErrors
+): number | null | undefined {
+	if (value === undefined) return undefined;
+	if (value === null) return null;
+	if (typeof value !== 'number' || !Number.isInteger(value)) {
+		addError(errors, field, `${field} must be an integer`);
+		return undefined;
+	}
+	if (value < 1) {
+		addError(errors, field, `${field} must be at least 1`);
+		return undefined;
+	}
+	return value;
+}
+
+function parseOptionalBoolean(
+	value: unknown,
+	field: string,
+	errors: ValidationErrors
+): boolean | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== 'boolean') {
+		addError(errors, field, `${field} must be a boolean`);
+		return undefined;
+	}
+	return value;
+}
+
+function compactUndefined<T extends Record<string, unknown>>(value: T): Partial<T> {
+	const result: Record<string, unknown> = {};
+	for (const [key, val] of Object.entries(value)) {
+		if (val !== undefined) result[key] = val;
+	}
+	return result as Partial<T>;
+}
+
+export function validateEventCreate(data: unknown): ValidationOk<EventCreatePayload> | ValidationFail {
+	if (!isPlainObject(data)) {
+		return { ok: false, errors: { _error: 'Expected a JSON object body' } };
+	}
+
+	const errors: ValidationErrors = {};
+	const unknownKeys = Object.keys(data).filter((key) => !createAllowedFields.has(key));
+	if (unknownKeys.length > 0) {
+		addError(errors, 'unknownFields', `Unexpected fields: ${unknownKeys.join(', ')}`);
+	}
+
+	const organizationId = parseRequiredString(data.organizationId, 'organizationId', errors);
+	const title = parseRequiredString(data.title, 'title', errors);
+	const location = parseRequiredString(data.location, 'location', errors);
+	const description = parseOptionalNullableString(data.description, 'description', errors);
+	const startTime = parseRequiredDate(data.startTime, 'startTime', errors);
+	const endTime = parseRequiredDate(data.endTime, 'endTime', errors);
+	const maxCapacity = parseOptionalInteger(data.maxCapacity, 'maxCapacity', errors);
+	const registrationRequired = parseOptionalBoolean(
+		data.registrationRequired,
+		'registrationRequired',
+		errors
+	);
+
+	if (startTime && endTime && startTime >= endTime) {
+		addError(errors, 'timeRange', 'startTime must be before endTime');
+	}
+
+	if (Object.keys(errors).length > 0) {
+		return { ok: false, errors };
+	}
+
+	const payload: EventCreatePayload = {
+		organizationId: organizationId as string,
+		title: title as string,
+		location: location as string,
+		startTime: startTime as Date,
+		endTime: endTime as Date,
+		description,
+		maxCapacity,
+		registrationRequired
+	};
+
+	return { ok: true, value: compactUndefined(payload) as EventCreatePayload };
+}
+
+export function validateEventUpdate(
+	data: unknown,
+	context: EventUpdateContext = {}
+): ValidationOk<EventUpdatePayload> | ValidationFail {
+	if (!isPlainObject(data)) {
+		return { ok: false, errors: { _error: 'Expected a JSON object body' } };
+	}
+
+	const errors: ValidationErrors = {};
+	const unknownKeys = Object.keys(data).filter((key) => !updateAllowedFields.has(key));
+	if (unknownKeys.length > 0) {
+		addError(errors, 'unknownFields', `Unexpected fields: ${unknownKeys.join(', ')}`);
+	}
+
+	const title = parseOptionalNonEmptyString(data.title, 'title', errors);
+	const location = parseOptionalNonEmptyString(data.location, 'location', errors);
+	const description = parseOptionalNullableString(data.description, 'description', errors);
+	const startTime = parseOptionalDate(data.startTime, 'startTime', errors);
+	const endTime = parseOptionalDate(data.endTime, 'endTime', errors);
+	const maxCapacity = parseOptionalInteger(data.maxCapacity, 'maxCapacity', errors);
+	const registrationRequired = parseOptionalBoolean(
+		data.registrationRequired,
+		'registrationRequired',
+		errors
+	);
+
+	const payload = compactUndefined({
+		title,
+		description,
+		location,
+		startTime,
+		endTime,
+		maxCapacity,
+		registrationRequired
+	});
+
+	if (Object.keys(payload).length === 0) {
+		addError(errors, 'emptyPayload', 'At least one field must be provided');
+	}
+
+	const effectiveStart = (payload.startTime as Date | undefined) ?? context.existingStartTime;
+	const effectiveEnd = (payload.endTime as Date | undefined) ?? context.existingEndTime;
+	if (effectiveStart && effectiveEnd && effectiveStart >= effectiveEnd) {
+		addError(errors, 'timeRange', 'startTime must be before endTime');
+	}
+
+	if (Object.keys(errors).length > 0) {
+		return { ok: false, errors };
+	}
+
+	return { ok: true, value: payload as EventUpdatePayload };
+}

--- a/src/lib/server/validation/events.ts
+++ b/src/lib/server/validation/events.ts
@@ -172,7 +172,9 @@ function compactUndefined<T extends Record<string, unknown>>(value: T): Partial<
 	return result as Partial<T>;
 }
 
-export function validateEventCreate(data: unknown): ValidationOk<EventCreatePayload> | ValidationFail {
+export function validateEventCreate(
+	data: unknown
+): ValidationOk<EventCreatePayload> | ValidationFail {
 	if (!isPlainObject(data)) {
 		return { ok: false, errors: { _error: 'Expected a JSON object body' } };
 	}

--- a/src/routes/api/events/+server.ts
+++ b/src/routes/api/events/+server.ts
@@ -3,19 +3,7 @@ import { db } from '$lib/server/db/index.js';
 import { events } from '$lib/server/db/schema.js';
 import { error as kitError, isHttpError, isRedirect, json } from '@sveltejs/kit';
 import { requireAuth, requireCanManageOrg } from '$lib/server/authz.js';
-
-function isNonEmptyString(value: unknown): value is string {
-	return typeof value === 'string' && value.trim().length > 0;
-}
-
-function parseDate(value: unknown): Date | null {
-	if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
-	if (typeof value === 'string') {
-		const parsed = new Date(value);
-		return Number.isNaN(parsed.getTime()) ? null : parsed;
-	}
-	return null;
-}
+import { validateEventCreate } from '$lib/server/validation/events.js';
 
 export async function GET() {
 	// Public list for now, if we want private drafts later, we can add authz here
@@ -32,41 +20,25 @@ export async function POST(event) {
 	// Server enforcement, students should not be able to POST /api/events unless they manage that org
 	const userId = requireAuth(event); // Blocks anonymous users
 
+	let data: unknown;
 	try {
-		const data = await event.request.json();
+		data = await event.request.json();
+	} catch {
+		return json({ error: 'Invalid JSON body' }, { status: 400 });
+	}
 
-		// Security: organizationId MUST come from the request for a create,
-		// but we validate it and then check membership on the server
-		const organizationId = data.organizationId;
-		if (!isNonEmptyString(organizationId)) {
-			return json({ error: 'organizationId is required' }, { status: 400 });
-		}
+	const validation = validateEventCreate(data);
+	if (!validation.ok) {
+		return json({ error: 'Validation failed', details: validation.errors }, { status: 400 });
+	}
 
-		if (!isNonEmptyString(data.title)) {
-			return json({ error: 'title is required' }, { status: 400 });
-		}
-		if (!isNonEmptyString(data.location)) {
-			return json({ error: 'location is required' }, { status: 400 });
-		}
-
-		// Drizzle timestamps are configured to expect Date objects.
-		const startTime = parseDate(data.startTime);
-		const endTime = parseDate(data.endTime);
-		if (!startTime) {
-			return json({ error: 'startTime must be a valid ISO date string' }, { status: 400 });
-		}
-		if (!endTime) {
-			return json({ error: 'endTime must be a valid ISO date string' }, { status: 400 });
-		}
-
+	try {
 		// Blocks: non-admin users who are not board_member/president for this org
-		await requireCanManageOrg(userId, organizationId);
+		await requireCanManageOrg(userId, validation.value.organizationId);
 
 		// Security: never trust client-provided createdBy
 		const insertData = {
-			...data,
-			startTime,
-			endTime,
+			...validation.value,
 			createdBy: userId
 		};
 

--- a/src/routes/api/events/[id]/+server.ts
+++ b/src/routes/api/events/[id]/+server.ts
@@ -3,15 +3,7 @@ import { db } from '$lib/server/db/index.js';
 import { events } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import { requireAuth, requireCanManageOrg } from '$lib/server/authz.js';
-
-function parseDate(value: unknown): Date | null {
-	if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
-	if (typeof value === 'string') {
-		const parsed = new Date(value);
-		return Number.isNaN(parsed.getTime()) ? null : parsed;
-	}
-	return null;
-}
+import { validateEventUpdate } from '$lib/server/validation/events.js';
 
 export async function PUT(event) {
 	const userId = requireAuth(event);
@@ -20,7 +12,7 @@ export async function PUT(event) {
 	// Load the event first to get the REAL orgId from the database.
 	// This prevents a user from editing another org's event by spoofing orgId in the body.
 	const existing = await db.query.events.findFirst({
-		columns: { id: true, organizationId: true },
+		columns: { id: true, organizationId: true, startTime: true, endTime: true },
 		where: eq(events.id, id)
 	});
 
@@ -29,26 +21,27 @@ export async function PUT(event) {
 	// Enforce per-org leadership (or admin)
 	await requireCanManageOrg(userId, existing.organizationId);
 
-	const patch = await event.request.json();
-
-	// If client sends ISO strings for timestamps, convert them to Date objects for Drizzle.
-	if ('startTime' in patch) {
-		const parsed = parseDate(patch.startTime);
-		if (!parsed)
-			return json({ error: 'startTime must be a valid ISO date string' }, { status: 400 });
-		patch.startTime = parsed;
-	}
-	if ('endTime' in patch) {
-		const parsed = parseDate(patch.endTime);
-		if (!parsed) return json({ error: 'endTime must be a valid ISO date string' }, { status: 400 });
-		patch.endTime = parsed;
+	let patch: unknown;
+	try {
+		patch = await event.request.json();
+	} catch {
+		return json({ error: 'Invalid JSON body' }, { status: 400 });
 	}
 
-	// Security: never allow clients to rewrite ownership fields.
-	delete patch.createdBy;
-	delete patch.organizationId;
+	const validation = validateEventUpdate(patch, {
+		existingStartTime: existing.startTime,
+		existingEndTime: existing.endTime
+	});
 
-	const updated = await db.update(events).set(patch).where(eq(events.id, id)).returning();
+	if (!validation.ok) {
+		return json({ error: 'Validation failed', details: validation.errors }, { status: 400 });
+	}
+
+	const updated = await db
+		.update(events)
+		.set(validation.value)
+		.where(eq(events.id, id))
+		.returning();
 	return json(updated[0]);
 }
 


### PR DESCRIPTION
## What changed
- added a shared validation helper for event input
- allowlisted safe fields for create and update
- rejected unknown/unexpected fields
- enforced required fields on create
- enforced valid time ranges (`startTime < endTime`)
- validated partial updates using existing stored event times
- prevented mass assignment / over-posting
- returned structured `400` validation errors for invalid input

## Why
Previously, the backend accepted too much client input and validation was split across routes, which made it easier for invalid or unexpected fields to slip through. This PR centralizes validation and makes the event API safer and more consistent. :contentReference[oaicite:0]{index=0}

## Files changed
- `+server.ts`
- `src/routes/api/events/[id]/+server.ts`
- `events.ts`
