### PR TITLE
Add backend event discovery filtering, search, and pagination for /api/events

### DIFF
--- a/src/lib/server/db/dataHelpers.ts
+++ b/src/lib/server/db/dataHelpers.ts
@@ -3,7 +3,7 @@
  * Handles missing schema fields by returning null for fields not yet implemented.
  */
 
-import { and, desc, eq, gte, ilike, inArray, lte, or, sql } from 'drizzle-orm';
+import { and, eq, gte, ilike, inArray, lte, or, sql } from 'drizzle-orm';
 import type { Event, Organization, EventTag, OrganizationCategory } from '$lib/types/index.js';
 import { db } from './index.js';
 import {
@@ -189,7 +189,7 @@ export async function getEventsForDiscovery(
 		eventsQuery = eventsQuery.where(whereExpression);
 	}
 	const eventRows = await eventsQuery
-		.orderBy(desc(events.startTime))
+		.orderBy(events.startTime)
 		.limit(pagination.pageSize)
 		.offset(offset);
 

--- a/src/lib/server/db/dataHelpers.ts
+++ b/src/lib/server/db/dataHelpers.ts
@@ -3,7 +3,7 @@
  * Handles missing schema fields by returning null for fields not yet implemented.
  */
 
-import { eq } from 'drizzle-orm';
+import { and, desc, eq, gte, ilike, inArray, lte, or, sql } from 'drizzle-orm';
 import type { Event, Organization, EventTag, OrganizationCategory } from '$lib/types/index.js';
 import { db } from './index.js';
 import {
@@ -88,6 +88,194 @@ export async function getAllEvents(): Promise<Event[]> {
 	);
 
 	return enrichedEvents;
+}
+
+export type EventDiscoveryFilters = {
+	organizationId?: string;
+	tagNames?: string[];
+	orgCategoryNames?: string[];
+	startDate?: Date;
+	endDate?: Date;
+	search?: string;
+};
+
+export type EventDiscoveryPagination = {
+	page: number;
+	pageSize: number;
+};
+
+export async function getEventsForDiscovery(
+	filters: EventDiscoveryFilters,
+	pagination: EventDiscoveryPagination
+): Promise<{ events: Event[]; total: number }> {
+	const tagNames = filters.tagNames ?? [];
+	const orgCategoryNames = filters.orgCategoryNames ?? [];
+
+	let tagEventIds: string[] | undefined;
+	if (tagNames.length > 0) {
+		const tagMatches = await db
+			.select({ eventId: eventTagAssignments.eventId })
+			.from(eventTagAssignments)
+			.innerJoin(eventTags, eq(eventTagAssignments.tagId, eventTags.id))
+			.where(inArray(eventTags.name, tagNames));
+		tagEventIds = Array.from(new Set(tagMatches.map((row) => row.eventId)));
+		if (tagEventIds.length === 0) {
+			return { events: [], total: 0 };
+		}
+	}
+
+	let orgIdsFromCategory: string[] | undefined;
+	if (orgCategoryNames.length > 0) {
+		const orgMatches = await db
+			.select({ organizationId: organizationCategoryAssignments.organizationId })
+			.from(organizationCategoryAssignments)
+			.innerJoin(
+				organizationCategories,
+				eq(organizationCategoryAssignments.categoryId, organizationCategories.id)
+			)
+			.where(inArray(organizationCategories.name, orgCategoryNames));
+		orgIdsFromCategory = Array.from(new Set(orgMatches.map((row) => row.organizationId)));
+		if (orgIdsFromCategory.length === 0) {
+			return { events: [], total: 0 };
+		}
+	}
+
+	let orgIdsFromSearch: string[] | undefined;
+	if (filters.search) {
+		const searchMatches = await db
+			.select({ id: organizations.id })
+			.from(organizations)
+			.where(ilike(organizations.name, `%${filters.search}%`));
+		orgIdsFromSearch = searchMatches.map((row) => row.id);
+	}
+
+	const whereClauses = [] as Array<ReturnType<typeof and>>;
+	if (filters.organizationId) {
+		whereClauses.push(eq(events.organizationId, filters.organizationId));
+	}
+	if (filters.startDate) {
+		whereClauses.push(gte(events.startTime, filters.startDate));
+	}
+	if (filters.endDate) {
+		whereClauses.push(lte(events.startTime, filters.endDate));
+	}
+	if (tagEventIds && tagEventIds.length > 0) {
+		whereClauses.push(inArray(events.id, tagEventIds));
+	}
+	if (orgIdsFromCategory && orgIdsFromCategory.length > 0) {
+		whereClauses.push(inArray(events.organizationId, orgIdsFromCategory));
+	}
+	if (filters.search) {
+		const searchTerm = `%${filters.search}%`;
+		const searchClauses = [ilike(events.title, searchTerm), ilike(events.description, searchTerm)];
+		if (orgIdsFromSearch && orgIdsFromSearch.length > 0) {
+			searchClauses.push(inArray(events.organizationId, orgIdsFromSearch));
+		}
+		whereClauses.push(or(...searchClauses));
+	}
+
+	const whereExpression = whereClauses.length > 0 ? and(...whereClauses) : undefined;
+	const offset = (pagination.page - 1) * pagination.pageSize;
+
+	let totalQuery = db.select({ count: sql<number>`count(*)` }).from(events);
+	if (whereExpression) {
+		totalQuery = totalQuery.where(whereExpression);
+	}
+	const totalResult = await totalQuery;
+	const total = totalResult[0]?.count ?? 0;
+
+	let eventsQuery = db.select().from(events);
+	if (whereExpression) {
+		eventsQuery = eventsQuery.where(whereExpression);
+	}
+	const eventRows = await eventsQuery
+		.orderBy(desc(events.startTime))
+		.limit(pagination.pageSize)
+		.offset(offset);
+
+	if (eventRows.length === 0) {
+		return { events: [], total };
+	}
+
+	const eventIds = eventRows.map((event) => event.id);
+	const orgIds = Array.from(new Set(eventRows.map((event) => event.organizationId)));
+
+	const [orgRows, tagRows, orgCategoryRows] = await Promise.all([
+		db.select().from(organizations).where(inArray(organizations.id, orgIds)),
+		db
+			.select({
+				eventId: eventTagAssignments.eventId,
+				tagId: eventTags.id,
+				tagName: eventTags.name,
+				tagColor: eventTags.color
+			})
+			.from(eventTagAssignments)
+			.innerJoin(eventTags, eq(eventTagAssignments.tagId, eventTags.id))
+			.where(inArray(eventTagAssignments.eventId, eventIds)),
+		db
+			.select({
+				organizationId: organizationCategoryAssignments.organizationId,
+				categoryId: organizationCategories.id,
+				categoryName: organizationCategories.name,
+				categoryColor: organizationCategories.color
+			})
+			.from(organizationCategoryAssignments)
+			.innerJoin(
+				organizationCategories,
+				eq(organizationCategoryAssignments.categoryId, organizationCategories.id)
+			)
+			.where(inArray(organizationCategoryAssignments.organizationId, orgIds))
+	]);
+
+	const orgById = new Map(orgRows.map((org) => [org.id, org]));
+	const tagsByEventId = new Map<string, Event['tags']>();
+	for (const row of tagRows) {
+		const existing = tagsByEventId.get(row.eventId) ?? [];
+		existing.push({ id: row.tagId, name: row.tagName, color: row.tagColor });
+		tagsByEventId.set(row.eventId, existing);
+	}
+
+	const categoriesByOrgId = new Map<string, Array<{ id: string; name: string; color: string }>>();
+	for (const row of orgCategoryRows) {
+		const existing = categoriesByOrgId.get(row.organizationId) ?? [];
+		existing.push({
+			id: row.categoryId,
+			name: row.categoryName,
+			color: row.categoryColor
+		});
+		categoriesByOrgId.set(row.organizationId, existing);
+	}
+
+	const enrichedEvents = eventRows.map((event) => {
+		const org = orgById.get(event.organizationId);
+		const orgCategories = categoriesByOrgId.get(event.organizationId) ?? [];
+		return {
+			id: event.id,
+			title: event.title,
+			description: event.description,
+			location: event.location,
+			startTime: event.startTime.toISOString(),
+			endTime: event.endTime.toISOString(),
+			imageUrl: null,
+			attendeeCount: null,
+			rsvpUrl: null,
+			feedbackUrl: null,
+			organizations: org
+				? [
+						{
+							id: org.id,
+							name: org.name,
+							abbreviation: null,
+							logoUrl: null,
+							categories: orgCategories
+						}
+					]
+				: [],
+			tags: tagsByEventId.get(event.id) ?? []
+		} satisfies Event;
+	});
+
+	return { events: enrichedEvents, total };
 }
 
 /**

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -74,6 +74,11 @@ export interface Event {
 		name: string;
 		abbreviation?: string | null; // BACKEND TODO: Add this column to organizations table
 		logoUrl?: string | null; // BACKEND TODO: Add this column to organizations table
+		categories?: Array<{
+			id: string;
+			name: string;
+			color: string;
+		}>;
 	}>; // BACKEND TODO: Join via event_organization_assignments (currently single org via organization_id)
 	tags?: Array<{
 		id: string;

--- a/src/routes/api/events/+server.ts
+++ b/src/routes/api/events/+server.ts
@@ -1,15 +1,213 @@
 // src/routes/api/events/+server.ts
 import { db } from '$lib/server/db/index.js';
 import { events } from '$lib/server/db/schema.js';
+import {
+	getEventsForDiscovery,
+	type EventDiscoveryFilters,
+	type EventDiscoveryPagination
+} from '$lib/server/db/dataHelpers.js';
 import { error as kitError, isHttpError, isRedirect, json } from '@sveltejs/kit';
 import { requireAuth, requireCanManageOrg } from '$lib/server/authz.js';
 import { validateEventCreate } from '$lib/server/validation/events.js';
 
-export async function GET() {
+type QueryValidation =
+	| { ok: true; value: { filters: EventDiscoveryFilters; pagination: EventDiscoveryPagination } }
+	| { ok: false; errors: Record<string, string> };
+
+const allowedQueryParams = new Set([
+	'organizationId',
+	'orgCategory',
+	'category',
+	'tag',
+	'date',
+	'startDate',
+	'endDate',
+	'q',
+	'page',
+	'pageSize'
+]);
+
+const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_PAGE_SIZE = 50;
+
+function addQueryError(errors: Record<string, string>, field: string, message: string) {
+	if (!errors[field]) errors[field] = message;
+}
+
+function parseOptionalUuid(
+	value: string | null,
+	field: string,
+	errors: Record<string, string>
+): string | undefined {
+	if (!value) return undefined;
+	const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+	if (!uuidPattern.test(value.trim())) {
+		addQueryError(errors, field, `${field} must be a valid UUID`);
+		return undefined;
+	}
+	return value.trim();
+}
+
+function parseOptionalPositiveInt(
+	value: string | null,
+	field: string,
+	errors: Record<string, string>,
+	options: { min: number; max?: number }
+): number | undefined {
+	if (value == null) return undefined;
+	if (!/^\d+$/.test(value)) {
+		addQueryError(errors, field, `${field} must be a positive integer`);
+		return undefined;
+	}
+	const parsed = Number.parseInt(value, 10);
+	if (parsed < options.min) {
+		addQueryError(errors, field, `${field} must be at least ${options.min}`);
+		return undefined;
+	}
+	if (options.max && parsed > options.max) {
+		addQueryError(errors, field, `${field} must be at most ${options.max}`);
+		return undefined;
+	}
+	return parsed;
+}
+
+function splitListParam(values: string[]): string[] {
+	return values
+		.flatMap((value) => value.split(','))
+		.map((value) => value.trim())
+		.filter((value) => value.length > 0);
+}
+
+function parseDateParam(
+	value: string | null,
+	field: string,
+	errors: Record<string, string>,
+	mode: 'start' | 'end'
+): Date | undefined {
+	if (!value) return undefined;
+	const trimmed = value.trim();
+	if (dateOnlyPattern.test(trimmed)) {
+		const suffix = mode === 'start' ? 'T00:00:00.000Z' : 'T23:59:59.999Z';
+		return new Date(`${trimmed}${suffix}`);
+	}
+	const parsed = new Date(trimmed);
+	if (Number.isNaN(parsed.getTime())) {
+		addQueryError(errors, field, `${field} must be a valid ISO date or date-time`);
+		return undefined;
+	}
+	return parsed;
+}
+
+function parseEventsQuery(url: URL): QueryValidation {
+	const errors: Record<string, string> = {};
+	const params = url.searchParams;
+	const unknownParams = Array.from(params.keys()).filter((key) => !allowedQueryParams.has(key));
+	if (unknownParams.length > 0) {
+		addQueryError(errors, 'unknownParams', `Unexpected query params: ${unknownParams.join(', ')}`);
+	}
+
+	const organizationId = parseOptionalUuid(params.get('organizationId'), 'organizationId', errors);
+
+	const tagValues = splitListParam(params.getAll('tag')).map((value) => value.toLowerCase());
+	if (params.has('tag') && tagValues.length === 0) {
+		addQueryError(errors, 'tag', 'tag must be a non-empty string or comma-separated list');
+	}
+	const tagNames = tagValues.length > 0 ? Array.from(new Set(tagValues)) : undefined;
+
+	const categoryValues = splitListParam([
+		...params.getAll('orgCategory'),
+		...params.getAll('category')
+	]).map((value) => value.toLowerCase().replace(/\s+/g, '_'));
+	if ((params.has('orgCategory') || params.has('category')) && categoryValues.length === 0) {
+		addQueryError(
+			errors,
+			'orgCategory',
+			'orgCategory must be a non-empty string or comma-separated list'
+		);
+	}
+	const orgCategoryNames =
+		categoryValues.length > 0 ? Array.from(new Set(categoryValues)) : undefined;
+
+	const searchRaw = params.get('q');
+	const search = searchRaw ? searchRaw.trim() : undefined;
+	if (search && search.length > 200) {
+		addQueryError(errors, 'q', 'q must be 200 characters or fewer');
+	}
+
+	const date = params.get('date');
+	const startDateRaw = params.get('startDate');
+	const endDateRaw = params.get('endDate');
+	if (date && (startDateRaw || endDateRaw)) {
+		addQueryError(errors, 'date', 'Use either date or startDate/endDate, not both');
+	}
+
+	let startDate: Date | undefined;
+	let endDate: Date | undefined;
+	if (date) {
+		if (!dateOnlyPattern.test(date.trim())) {
+			addQueryError(errors, 'date', 'date must be in YYYY-MM-DD format');
+		} else {
+			startDate = parseDateParam(date, 'date', errors, 'start');
+			endDate = parseDateParam(date, 'date', errors, 'end');
+		}
+	} else {
+		startDate = parseDateParam(startDateRaw, 'startDate', errors, 'start');
+		endDate = parseDateParam(endDateRaw, 'endDate', errors, 'end');
+	}
+
+	if (startDate && endDate && startDate > endDate) {
+		addQueryError(errors, 'dateRange', 'startDate must be on or before endDate');
+	}
+
+	const page = parseOptionalPositiveInt(params.get('page'), 'page', errors, { min: 1 }) ?? 1;
+	const pageSize =
+		parseOptionalPositiveInt(params.get('pageSize'), 'pageSize', errors, {
+			min: 1,
+			max: MAX_PAGE_SIZE
+		}) ?? 20;
+
+	if (Object.keys(errors).length > 0) {
+		return { ok: false, errors };
+	}
+
+	return {
+		ok: true,
+		value: {
+			filters: {
+				organizationId,
+				tagNames,
+				orgCategoryNames,
+				startDate,
+				endDate,
+				search
+			},
+			pagination: { page, pageSize }
+		}
+	};
+}
+
+export async function GET({ url }) {
 	// Public list for now, if we want private drafts later, we can add authz here
+	const parsed = parseEventsQuery(url);
+	if (!parsed.ok) {
+		return json({ error: 'Invalid query params', details: parsed.errors }, { status: 400 });
+	}
+
 	try {
-		const allEvents = await db.select().from(events);
-		return json(allEvents);
+		const { filters, pagination } = parsed.value;
+		const { events, total } = await getEventsForDiscovery(filters, pagination);
+		const totalPages = total === 0 ? 0 : Math.ceil(total / pagination.pageSize);
+		return json({
+			data: events,
+			pagination: {
+				page: pagination.page,
+				pageSize: pagination.pageSize,
+				total,
+				totalPages,
+				hasNext: pagination.page < totalPages,
+				hasPrev: pagination.page > 1
+			}
+		});
 	} catch (error) {
 		console.error('Error fetching events:', error);
 		return json({ error: 'Failed to fetch events' }, { status: 500 });


### PR DESCRIPTION
## Summary
Implements the backend side of event discovery/filtering on `GET /api/events`.

## What changed
- Added query param parsing and validation for event discovery
- Added backend filtering for:
  - `organizationId`
  - `tag`
  - `orgCategory` / `category`
  - `q` (search)
  - `date`
  - `startDate` / `endDate`
- Added pagination with:
  - `page`
  - `pageSize`
  - `total`
  - `totalPages`
  - `hasNext`
  - `hasPrev`
- Replaced raw event reads with enriched discovery responses
- Returned joined event data including:
  - organizations
  - tags
  - organization categories

## Why
Previously, Search/Discover mostly loaded full event data and filtered on the frontend. This change moves discovery filtering to the backend so the server is the source of truth and only matching events are returned. Now the frontend must implement this so the webapp isnt doing client side filtering anymore, this server side filtering makes it so less data is sent, backend is the source of truth, pagination becomes real, more consistent behavior for filtering, and better for future features(bigger datasets).

## Testing
Tested `GET /api/events` in the browser with:
- no query params
- tag filter
- category/orgCategory filter
- organizationId filter
- search query
- date and date range filters
- pagination params
- invalid params (bad UUID, bad dates, invalid page/pageSize)

## Notes
- Response shape now returns `{ data, pagination }`